### PR TITLE
Compatibility with bjornstar/blob-polyfill

### DIFF
--- a/FileReader.js
+++ b/FileReader.js
@@ -122,7 +122,7 @@
       // Create a read stream from a blob-polyfill Blob
       if (file.data) {
         process.nextTick(function () {
-          stream.emit('data', Buffer.from(file.data));
+          stream.emit('data', Buffer.from(file.data, "ascii"));
           stream.emit('end');
         });
         file.stream = stream;

--- a/FileReader.js
+++ b/FileReader.js
@@ -119,6 +119,15 @@
         return;
       }
 
+      // Create a read stream from a blob-polyfill Blob
+      if (file.data) {
+        process.nextTick(function () {
+          stream.emit('data', Buffer.from(file.data));
+          stream.emit('end');
+        });
+        file.stream = stream;
+        return;
+      }
 
       // Create a read stream from a file
       if (file.path) {
@@ -262,7 +271,7 @@
 
     function readFile(_file, format, encoding) {
       file = _file;
-      if (!file || !file.name || !(file.path || file.stream || file.buffer)) {
+      if (!file || !(file.name || file.data) || !(file.path || file.stream || file.buffer || file.data)) {
         throw new Error("cannot read as File: " + JSON.stringify(file));
       }
       if (0 !== self.readyState) {


### PR DESCRIPTION
Add compatibility with the fake Blob objects created by [blob-polyfill](https://github.com/bjornstar/blob-polyfill) to allow the use of [readable-blob-stream](https://github.com/Joris-van-der-Wel/readable-blob-stream) with NodeJS.

This is mainly useful for headless unit testing of browser code that uses Blob/FileReader.